### PR TITLE
Ensure /run/secrets exists before touching auth.conf

### DIFF
--- a/openvpn.sh
+++ b/openvpn.sh
@@ -5,6 +5,7 @@ if [ -n "$REGION" ]; then
   set -- "$@" '--config' "${REGION}.ovpn"
 fi
 
+mkdir -p /run/secrets
 touch /run/secrets/auth_conf
 
 if [ -n "$USERNAME" -a -n "$PASSWORD" ]; then


### PR DESCRIPTION
Simple change to `mkdir -p /run/secrets` before we run `touch /run/secrets/auth_conf` in case the directory doesn't exist.